### PR TITLE
Add MJML class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 /env/
+__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,28 @@ html = mjml2html('''
 ''')
 ```
 
+or you can parse the MJML template and render it later:
+
+```py
+from mjml import parse
+
+m = parse('''
+<mjml>
+  <mj-body>
+    <mj-section>
+      <mj-column>
+        <mj-image width="100px" src="/assets/img/logo-small.png"></mj-image>
+        <mj-divider border-color="#F45E43"></mj-divider>
+        <mj-text font-size="20px" color="#F45E43" font-family="helvetica">Hello World</mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>
+'''
+)
+html = m.render()
+```
+
 ## Development
 
 ```sh
@@ -35,4 +57,11 @@ python -m venv env
 . env/bin/activate
 pip install -r requirements.txt
 maturin develop
+```
+
+### Run tests
+
+Currently, the tests are used for local testing only.
+```sh
+pytest -svv
 ```

--- a/mjml.pyi
+++ b/mjml.pyi
@@ -1,2 +1,25 @@
+class MJML:
+
+    @staticmethod
+    def parse(input: str) -> MJML:
+        """Parse MJML string and return instance of MJML object."""
+
+    def render(self) -> str:
+        """Render MJML template to HTML string."""
+
+    def title(self) -> str:
+        """Return title of MJML template."""
+
+    def preview(self) -> str:
+        """Return preview of MJML template."""
+
+    @property
+    def template(self) -> str:
+        """Return MJML template string."""
+
+def parse(input: str) -> MJML:
+    """Parse MJML string and return instance of MJML object."""
+
+
 def mjml2html(input: str) -> str:
     """Convert MJML string to HTML string."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 maturin
+pytest

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,22 +1,72 @@
-use pyo3::prelude::*;
-use pyo3::exceptions::PyValueError;
 use mrml;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+#[pyclass]
+struct MJML {
+    root: mrml::mjml::MJML,
+    template: String,
+}
+
+#[pymethods]
+impl MJML {
+    #[staticmethod]
+    fn parse(input: String) -> PyResult<MJML> {
+        let template = input.clone();
+        return match mrml::parse(input) {
+            Ok(root) => Ok(MJML {
+                root,
+                template,
+            }),
+            Err(e) => return Err(PyValueError::new_err(e.to_string())),
+        };
+    }
+
+    fn render(&self) -> PyResult<String> {
+        let opts = mrml::prelude::render::Options::default();
+        return match self.root.render(&opts) {
+            Ok(content) => Ok(content),
+            Err(e) => Err(PyValueError::new_err(e.to_string())),
+        };
+    }
+
+    #[getter]
+    fn title(&self) -> PyResult<String> {
+        return match self.root.get_title() {
+            Some(title) => Ok(title),
+            None => Err(PyValueError::new_err("No title found")),
+        };
+    }
+
+    #[getter]
+    fn preview(&self) -> PyResult<String> {
+        return match self.root.get_preview() {
+            Some(preview) => Ok(preview),
+            None => Err(PyValueError::new_err("No preview found")),
+        };
+    }
+
+    #[getter]
+    fn template(&self) -> PyResult<String> {
+        return Ok(self.template.clone());
+    }
+}
+
+#[pyfunction]
+fn parse(input: String) -> PyResult<MJML> {
+    return MJML::parse(input);
+}
 
 #[pyfunction]
 fn mjml2html(input: String) -> PyResult<String> {
-    let root = match mrml::parse(input) {
-        Ok(root) => root,
-        Err(e) => return Err(PyValueError::new_err(e.to_string())),
-    };
-    let opts = mrml::prelude::render::Options::default();
-    return match root.render(&opts) {
-        Ok(content) => Ok(content),
-        Err(e) => Err(PyValueError::new_err(e.to_string()))
-    };
+    let root = MJML::parse(input)?;
+    return root.render();
 }
 
 #[pymodule]
 fn mjml(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_class::<MJML>()?;
     m.add_function(wrap_pyfunction!(mjml2html, m)?)?;
+    m.add_function(wrap_pyfunction!(parse, m)?)?;
     Ok(())
 }

--- a/tests/files/case1_result.html
+++ b/tests/files/case1_result.html
@@ -1,0 +1,24 @@
+<!doctype html><html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office"><head><title></title><!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]--><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<style type="text/css">
+#outlook a { padding: 0; }
+body { margin: 0; padding: 0; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
+table, td { border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
+img { border: 0; height: auto; line-height: 100%; outline: none; text-decoration: none; -ms-interpolation-mode: bicubic; }
+p { display: block; margin: 13px 0; }
+</style>
+<!--[if mso]>
+<noscript>
+<xml>
+<o:OfficeDocumentSettings>
+  <o:AllowPNG/>
+  <o:PixelsPerInch>96</o:PixelsPerInch>
+</o:OfficeDocumentSettings>
+</xml>
+</noscript>
+<![endif]-->
+<!--[if lte mso 11]>
+<style type="text/css">
+.mj-outlook-group-fix { width:100% !important; }
+</style>
+<![endif]-->
+</head><body style="word-spacing:normal;"><div></div></body></html>

--- a/tests/files/case1_template.mjml
+++ b/tests/files/case1_template.mjml
@@ -1,0 +1,3 @@
+<mjml>
+  <mj-body></mj-body>
+</mjml>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,73 @@
+import pathlib
+
+import pytest
+import mjml
+
+
+@pytest.mark.parametrize(
+    'template_path, expected_path',
+    [
+        ('tests/files/case1_template.mjml', 'tests/files/case1_result.html'),
+    ]
+)
+def test_mjml2html(template_path, expected_path):
+    """Basic test for mjml2html function."""
+    template = pathlib.Path(template_path).read_text()
+    expected = pathlib.Path(expected_path).read_text()
+
+    html = mjml.mjml2html(template)
+
+    assert html == expected
+
+
+@pytest.mark.parametrize(
+    'template_path, expected_path',
+    [
+        ('tests/files/case1_template.mjml', 'tests/files/case1_result.html'),
+    ]
+)
+def test_parse_render(template_path, expected_path):
+    """Test for parse and render function."""
+    template = pathlib.Path(template_path).read_text()
+    expected = pathlib.Path(expected_path).read_text()
+
+    m = mjml.parse(template)    
+    html = m.render()
+    
+    assert html == expected
+
+
+def test_parse_error():
+    """Test for parse error."""
+    with pytest.raises(ValueError):
+        mjml.parse('</mjml>')
+
+def test_mjml_title_property():
+    """Test for get_title function."""
+    m = mjml.parse('''
+      <mjml>
+        <mj-head>
+          <mj-title>Hello MJML Title</mj-title>
+        </mj-head>
+      </mjml>
+    ''')
+    assert m.title == 'Hello MJML Title'
+
+
+def test_mjml_preview_property():
+    """Test for get_title function."""
+    m = mjml.parse('''
+      <mjml>
+       <mj-head>
+         <mj-preview>Hello MJML Preview</mj-preview>
+       </mj-head>
+      </mjml>
+    ''')
+    assert m.preview == 'Hello MJML Preview'
+
+
+def test_mjml_template_property():
+    """Test for get_title function."""
+    template = pathlib.Path('tests/files/case1_template.mjml').read_text()
+    m = mjml.parse(template)
+    assert m.template == template


### PR DESCRIPTION
Add a new function parse and MJML class that can be used for the parsing template in one place and rendering it in another. Specially useful in cases, when templates are preloaded at the application start and then are rendered on demand.