### PR TITLE
Add license to project classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ description = "A Python wrapper for MRML (Rust port of MJML)."
 readme = "README.md"
 requires-python = ">=3.7"
 classifiers = [
+    "License :: OSI Approved :: MIT License",
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",


### PR DESCRIPTION
This allows tools such as [python-license-check](https://github.com/dhatim/python-license-check) to correctly identify the license.