### PR TITLE
Upgrade to MRML 3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +126,15 @@ name = "indoc"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -174,11 +189,12 @@ dependencies = [
 
 [[package]]
 name = "mrml"
-version = "3.0.4"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11090cceb14c2eaf9d10c1503937b3a53323f322c475f409c1e51a0d86949a8d"
+checksum = "70b2e3b2ec6b01dcced4bdc6f446c85d9a48cf7c995e357b3b086ec9ab310211"
 dependencies = [
  "indexmap",
+ "itertools",
  "mrml-json-macros",
  "mrml-macros",
  "mrml-print-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ name = "mjml"
 crate-type = ["cdylib"]
 
 [dependencies]
-mrml = "3.0.4"
+mrml = "3.1.0"
 pyo3 = { version = "0.20.2", features = ["abi3-py37", "extension-module"] }

--- a/tests/test_mjml2html.py
+++ b/tests/test_mjml2html.py
@@ -140,3 +140,15 @@ class TestIncludeLoader(unittest.TestCase):
             include_loader=strings.__getitem__,
         )
         self.assertEqual(result, expected)
+
+    def test_include_css(self):
+        mjml = """
+        <mjml>
+            <mj-head>
+                <mj-include path="styles.css" type="css" />
+            </mj-head>
+        </mjml>
+        """
+        strings = {"styles.css": ".some-class { font-family: monospace }"}
+        result = mjml2html(mjml, include_loader=strings.__getitem__)
+        self.assertRegex(result, r"<style type=\"text/css\">.some-class { font-family: monospace }</style>")


### PR DESCRIPTION
Great developer instructions! I was able to make this change with basically no knowledge of rust. Pulling in the fix for [this issue](https://github.com/jdrouet/mrml/issues/386), which allows using css files with mj-include.