### PR TITLE
Add license pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "maturin"
 name = "mjml-python"
 description = "A Python wrapper for MRML (Rust port of MJML)."
 readme = "README.md"
+license = "MIT"
 requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Rust",


### PR DESCRIPTION
Many tools rely on `pyproject.toml` containing the license (e.g., dependency license checkers). So it's good to have it defined there.